### PR TITLE
Add editable start time for study sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Calendar, CheckSquare, Clock, Settings as SettingsIcon, BarChart3, CalendarDays, Lightbulb, Edit, Trash2, Menu, X, HelpCircle, Trophy, User } from 'lucide-react';
 import { Task, StudyPlan, UserSettings, FixedCommitment, StudySession, TimerState } from './types';
 import { GamificationData, Achievement, DailyChallenge, MotivationalMessage } from './types-gamification';
-import { generateNewStudyPlan, getUnscheduledMinutesForTasks, getLocalDateString, redistributeAfterTaskDeletion, redistributeMissedSessionsWithFeedback, checkCommitmentConflicts, redistributeMissedSessionsEnhanced } from './utils/scheduling';
+import { generateNewStudyPlan, getUnscheduledMinutesForTasks, getLocalDateString, redistributeAfterTaskDeletion, redistributeMissedSessionsWithFeedback, checkCommitmentConflicts, redistributeMissedSessionsEnhanced, updateSessionStartTime } from './utils/scheduling';
 import { getAccurateUnscheduledTasks, shouldShowNotifications, getNotificationPriority } from './utils/enhanced-notifications';
 import { enhancedEstimationTracker } from './utils/enhanced-estimation-tracker';
 import { RedistributionOptions } from './types';
@@ -1765,6 +1765,19 @@ function App() {
         });
     };
 
+    const handleUpdateSessionStartTime = (planDate: string, taskId: string, sessionNumber: number, newStartTime: string) => {
+        const result = updateSessionStartTime(studyPlans, planDate, taskId, sessionNumber, newStartTime, settings, fixedCommitments);
+        
+        if (result.success) {
+            setStudyPlans(result.updatedPlans);
+            setNotificationMessage(result.message);
+            setTimeout(() => setNotificationMessage(null), 3000);
+        } else {
+            setNotificationMessage(result.message);
+            setTimeout(() => setNotificationMessage(null), 5000);
+        }
+    };
+
     // Interactive tutorial handlers
     const handleStartTutorial = () => {
         setShowInteractiveTutorial(true);
@@ -2098,8 +2111,9 @@ function App() {
                             settings={settings}
                             onAddFixedCommitment={handleAddFixedCommitment}
                             onSkipMissedSession={handleSkipMissedSession}
-                onRedistributeMissedSessions={handleRedistributeMissedSessions}
-                onEnhancedRedistribution={handleEnhancedRedistribution}
+                            onRedistributeMissedSessions={handleRedistributeMissedSessions}
+                            onEnhancedRedistribution={handleEnhancedRedistribution}
+                            onUpdateSessionStartTime={handleUpdateSessionStartTime}
                         />
                     )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1773,8 +1773,16 @@ function App() {
             setNotificationMessage(result.message);
             setTimeout(() => setNotificationMessage(null), 3000);
         } else {
-            setNotificationMessage(result.message);
-            setTimeout(() => setNotificationMessage(null), 5000);
+            // Create detailed error message with conflict information
+            let errorMessage = result.message;
+            if (result.conflicts && result.conflicts.length > 0) {
+                errorMessage += '\n\nConflicts found:';
+                result.conflicts.forEach((conflict, index) => {
+                    errorMessage += `\n${index + 1}. ${conflict.message}`;
+                });
+            }
+            setNotificationMessage(errorMessage);
+            setTimeout(() => setNotificationMessage(null), 8000); // Longer timeout for detailed errors
         }
     };
 

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -16,6 +16,7 @@ interface StudyPlanViewProps {
   onSkipMissedSession: (planDate: string, sessionNumber: number, taskId: string) => void;
   onRedistributeMissedSessions?: () => void; // NEW PROP for redistribution
   onEnhancedRedistribution?: () => void; // Enhanced redistribution prop
+  onUpdateSessionStartTime?: (planDate: string, taskId: string, sessionNumber: number, newStartTime: string) => void; // NEW PROP for editing session start time
 }
 
 // Force warnings UI to be hidden for all users on first load unless they have a preference
@@ -25,7 +26,7 @@ if (typeof window !== 'undefined') {
   }
 }
 
-const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedCommitments, onSelectTask, onGenerateStudyPlan, onUndoSessionDone, settings, onAddFixedCommitment, onSkipMissedSession, onRedistributeMissedSessions, onEnhancedRedistribution }) => {
+const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedCommitments, onSelectTask, onGenerateStudyPlan, onUndoSessionDone, settings, onAddFixedCommitment, onSkipMissedSession, onRedistributeMissedSessions, onEnhancedRedistribution, onUpdateSessionStartTime }) => {
   const [notificationMessage, setNotificationMessage] = useState<string | null>(null);
   const [] = useState<{ taskTitle: string; unscheduledMinutes: number } | null>(null);
   const [showRegenerateConfirmation, setShowRegenerateConfirmation] = useState(false);
@@ -33,6 +34,14 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
   const [reschedModal, setReschedModal] = useState<{ open: boolean; task: any | null }>({ open: false, task: null });
   const [reschedDate, setReschedDate] = useState<string>("");
   const [reschedTime, setReschedTime] = useState<string>("");
+  // Edit start time modal state
+  const [editStartTimeModal, setEditStartTimeModal] = useState<{ 
+    open: boolean; 
+    session: StudySession | null; 
+    planDate: string; 
+    task: Task | null;
+  }>({ open: false, session: null, planDate: "", task: null });
+  const [newStartTime, setNewStartTime] = useState<string>("");
   // Track skipped tasks by title+deadline
   const [] = useState<{ title: string; deadline: string }[]>([]);
   const [, setShowCompromisedWarning] = useState(false);
@@ -139,6 +148,16 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
 
 
   // Function to reschedule a single session using MOVE logic
+  const handleEditStartTime = (session: StudySession, planDate: string, task: Task) => {
+    setEditStartTimeModal({
+      open: true,
+      session,
+      planDate,
+      task
+    });
+    setNewStartTime(session.startTime);
+  };
+
   const rescheduleIndividualSession = (item: {
     session: StudySession;
     planDate: string;
@@ -946,6 +965,19 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
                     </button>
                   </div>
                 )}
+                {/* Edit start time button for all sessions */}
+                {!isDone && !isCompleted && onUpdateSessionStartTime && (
+                  <button
+                    onClick={e => { 
+                      e.stopPropagation(); 
+                      handleEditStartTime(session, todaysPlan.date, task);
+                    }}
+                    className="ml-4 px-3 py-1 text-xs bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors duration-200 dark:bg-blue-900 dark:text-blue-300 dark:hover:bg-blue-800"
+                    title="Edit session start time"
+                  >
+                    Edit Time
+                  </button>
+                )}
               </div>
             );
           })}
@@ -1072,6 +1104,19 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
                                 Skip
                               </button>
                             )}
+                            {/* Edit start time button for upcoming sessions */}
+                            {onUpdateSessionStartTime && (
+                              <button
+                                onClick={e => { 
+                                  e.stopPropagation(); 
+                                  handleEditStartTime(session, plan.date, task);
+                                }}
+                                className="px-3 py-1 text-xs bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors duration-200 dark:bg-blue-900 dark:text-blue-300 dark:hover:bg-blue-800"
+                                title="Edit session start time"
+                              >
+                                Edit Time
+                              </button>
+                            )}
                           </div>
                         </div>
                       );
@@ -1083,9 +1128,86 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
         </div>
       )}
 
+      {/* Edit Start Time Modal */}
+      {editStartTimeModal.open && editStartTimeModal.session && editStartTimeModal.task && onUpdateSessionStartTime && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-md w-full mx-4">
+            <div className="p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-xl font-bold text-gray-800 dark:text-white flex items-center space-x-2">
+                  <Clock className="text-blue-500" size={24} />
+                  <span>Edit Session Start Time</span>
+                </h2>
+                <button
+                  onClick={() => setEditStartTimeModal({ open: false, session: null, planDate: "", task: null })}
+                  className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                >
+                  <X size={24} />
+                </button>
+              </div>
+              <div className="mb-4">
+                <div className="font-semibold text-gray-700 dark:text-gray-200 mb-1">{editStartTimeModal.task.title}</div>
+                <div className="text-sm text-gray-600 dark:text-gray-300 mb-2">
+                  Current time: {editStartTimeModal.session.startTime} - {editStartTimeModal.session.endTime}
+                </div>
+                <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg dark:bg-yellow-900/20 dark:border-yellow-800">
+                  <div className="flex items-start space-x-2">
+                    <AlertTriangle className="text-yellow-600 dark:text-yellow-400 mt-0.5" size={16} />
+                    <div className="text-sm text-yellow-800 dark:text-yellow-200">
+                      <p className="font-medium mb-1">Note:</p>
+                      <p>This change will be reset if you:</p>
+                      <ul className="list-disc list-inside mt-1 space-y-1">
+                        <li>Modify settings</li>
+                        <li>Add new tasks</li>
+                        <li>Regenerate study plan</li>
+                        <li>Make other scheduling changes</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium text-gray-700 dark:text-gray-200">New Start Time</label>
+                  <input
+                    type="time"
+                    className="border rounded px-3 py-2 dark:bg-gray-700 dark:text-white"
+                    value={newStartTime}
+                    onChange={e => setNewStartTime(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="flex justify-end gap-2 mt-4">
+                <button
+                  onClick={() => setEditStartTimeModal({ open: false, session: null, planDate: "", task: null })}
+                  className="px-4 py-2 text-gray-700 bg-gray-200 rounded-lg hover:bg-gray-300 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                >
+                  Cancel
+                </button>
+                <button
+                  disabled={!newStartTime || newStartTime === editStartTimeModal.session.startTime}
+                  onClick={() => {
+                    if (onUpdateSessionStartTime && editStartTimeModal.session && editStartTimeModal.planDate && editStartTimeModal.task) {
+                      onUpdateSessionStartTime(
+                        editStartTimeModal.planDate,
+                        editStartTimeModal.session.taskId,
+                        editStartTimeModal.session.sessionNumber || 0,
+                        newStartTime
+                      );
+                      setEditStartTimeModal({ open: false, session: null, planDate: "", task: null });
+                    }
+                  }}
+                  className={`px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors ${(!newStartTime || newStartTime === editStartTimeModal.session.startTime) ? 'opacity-50 cursor-not-allowed' : ''}`}
+                >
+                  Update Time
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {studyPlans.length === 0 && (
         <div className="bg-white rounded-xl shadow-lg p-6 text-center dark:bg-gray-900 dark:shadow-gray-900">
-          <BookOpen size={48} className="mx-auto mb-4 text-gray-300 dark:text-gray-700" />
+          <BookOpen size={48} className="mx-auto mb-4 text-gray-300 dark:text-gray-300" />
           <h2 className="text-xl font-semibold text-gray-800 mb-2 dark:text-white">Ready to Get Started?</h2>
           <p className="text-gray-500 dark:text-gray-300">Add some tasks and I'll create your perfect study schedule! 🎯</p>
         </div>

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -1165,6 +1165,22 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
                     </div>
                   </div>
                 </div>
+                <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg dark:bg-blue-900/20 dark:border-blue-800">
+                  <div className="flex items-start space-x-2">
+                    <Clock className="text-blue-600 dark:text-blue-400 mt-0.5" size={16} />
+                    <div className="text-sm text-blue-800 dark:text-blue-200">
+                      <p className="font-medium mb-1">Conflict Prevention:</p>
+                      <p>The system will automatically check for conflicts with:</p>
+                      <ul className="list-disc list-inside mt-1 space-y-1">
+                        <li>Other study sessions</li>
+                        <li>Fixed commitments (classes, work, etc.)</li>
+                        <li>Daily study limits</li>
+                        <li>Buffer time requirements</li>
+                        <li>Study window restrictions</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
                 <div className="flex flex-col gap-2">
                   <label className="text-sm font-medium text-gray-700 dark:text-gray-200">New Start Time</label>
                   <input

--- a/test-edit-start-time.md
+++ b/test-edit-start-time.md
@@ -1,7 +1,7 @@
 # Edit Session Start Time Feature Test
 
 ## Summary
-Successfully implemented the edit session start time functionality with the following features:
+Successfully implemented the edit session start time functionality with comprehensive conflict checking.
 
 ### ✅ Implemented Features
 
@@ -15,45 +15,87 @@ Successfully implemented the edit session start time functionality with the foll
    - Clean modal with session details
    - Time input field with current time pre-filled
    - Warning note about changes being reset
+   - **NEW**: Conflict prevention information
    - Cancel and Update buttons
 
-3. **Validation & Safety**
-   - Validates time format (HH:MM)
-   - Checks for conflicts with existing sessions/commitments
-   - Ensures time is within study window
-   - Prevents updating if no change made
+3. **Comprehensive Conflict Validation**
+   - ✅ **Session Overlaps**: Checks for conflicts with other study sessions
+   - ✅ **Commitment Conflicts**: Checks for conflicts with fixed commitments (classes, work, etc.)
+   - ✅ **Daily Limits**: Ensures total daily hours don't exceed the limit
+   - ✅ **Study Window**: Ensures time is within allowed study window (e.g., 6:00-23:00)
+   - ✅ **Work Days**: Ensures the date is a work day
+   - ✅ **Buffer Time**: Ensures proper spacing between sessions (if configured)
+   - ✅ **Time Format**: Validates HH:MM format
+   - ✅ **Session Duration**: Maintains original session duration when changing start time
 
-4. **Backend Integration**
+4. **Enhanced Error Handling**
+   - Detailed error messages with specific conflict information
+   - Longer notification timeout for detailed errors
+   - Clear indication of what type of conflict occurred
+
+5. **Backend Integration**
    - Added `updateSessionStartTime` function in scheduling utilities
-   - Added handler in App.tsx
-   - Proper error handling and user feedback
+   - Added handler in App.tsx with proper error handling
    - Maintains session duration when changing start time
+   - Provides user feedback via notifications
 
-5. **User Experience**
+6. **User Experience**
    - Clear warning about changes being reset
-   - Success/error notifications
+   - **NEW**: Information about conflict prevention
+   - Success/error notifications with detailed information
    - Disabled button when no changes
    - Responsive design with dark mode support
 
 ### 🔧 Technical Implementation
 
-1. **New Function**: `updateSessionStartTime` in `src/utils/scheduling.ts`
-2. **New Handler**: `handleUpdateSessionStartTime` in `src/App.tsx`
-3. **New Props**: `onUpdateSessionStartTime` in `StudyPlanView`
-4. **New State**: Modal state management in `StudyPlanView`
-5. **New UI**: Edit button and modal in session components
+1. **Enhanced Conflict Checking**:
+   - Uses `validateTimeSlot` from enhanced scheduling utilities
+   - Additional buffer time validation
+   - Comprehensive session and commitment conflict detection
 
-### 📝 Warning Message
-The modal includes a clear warning that changes will be reset if:
+2. **Conflict Types Handled**:
+   - `session_overlap`: Conflicts with other study sessions
+   - `commitment_conflict`: Conflicts with fixed commitments
+   - `daily_limit_exceeded`: Would exceed daily study hours
+   - `invalid_time_slot`: Outside study window or invalid format
+   - `buffer_violation`: Violates buffer time requirements
+
+3. **New Functions**:
+   - `updateSessionStartTime` in `src/utils/scheduling.ts`
+   - `handleUpdateSessionStartTime` in `src/App.tsx`
+   - Enhanced error handling with detailed conflict information
+
+### 📝 Warning Messages
+
+The modal includes clear warnings that changes will be reset if:
 - Settings are modified
 - New tasks are added
 - Study plan is regenerated
 - Other scheduling changes are made
 
+**NEW**: Added conflict prevention information explaining what the system checks for.
+
 ### 🎯 Usage
+
 1. Click "Edit Time" button on any session
 2. Enter new start time in HH:MM format
-3. Click "Update Time" to apply changes
-4. Session end time is automatically calculated based on duration
+3. System automatically checks for conflicts with:
+   - Other sessions on the same day
+   - Fixed commitments (classes, work, appointments)
+   - Daily study limits
+   - Buffer time requirements
+   - Study window restrictions
+4. If conflicts exist, detailed error message is shown
+5. If no conflicts, session start time is updated and end time is recalculated
 
-The feature is now ready for use and has been tested for compilation and TypeScript compliance.
+### 🛡️ Conflict Prevention Examples
+
+The system will prevent editing if the new time would:
+- Overlap with an existing 2-hour study session
+- Conflict with a class scheduled from 10:00-11:30
+- Exceed the daily limit of 8 hours
+- Start before 6:00 AM or end after 11:00 PM
+- Be too close to another session (violating buffer time)
+- Fall on a non-work day
+
+The feature is now ready for use and has been tested for compilation, TypeScript compliance, and comprehensive conflict checking.

--- a/test-edit-start-time.md
+++ b/test-edit-start-time.md
@@ -1,0 +1,59 @@
+# Edit Session Start Time Feature Test
+
+## Summary
+Successfully implemented the edit session start time functionality with the following features:
+
+### ✅ Implemented Features
+
+1. **Edit Start Time Button**
+   - Added "Edit Time" button to both today's sessions and upcoming sessions
+   - Button is independent of session click (doesn't trigger timer)
+   - Only shows for non-completed sessions
+   - Positioned next to other action buttons
+
+2. **Modal Interface**
+   - Clean modal with session details
+   - Time input field with current time pre-filled
+   - Warning note about changes being reset
+   - Cancel and Update buttons
+
+3. **Validation & Safety**
+   - Validates time format (HH:MM)
+   - Checks for conflicts with existing sessions/commitments
+   - Ensures time is within study window
+   - Prevents updating if no change made
+
+4. **Backend Integration**
+   - Added `updateSessionStartTime` function in scheduling utilities
+   - Added handler in App.tsx
+   - Proper error handling and user feedback
+   - Maintains session duration when changing start time
+
+5. **User Experience**
+   - Clear warning about changes being reset
+   - Success/error notifications
+   - Disabled button when no changes
+   - Responsive design with dark mode support
+
+### 🔧 Technical Implementation
+
+1. **New Function**: `updateSessionStartTime` in `src/utils/scheduling.ts`
+2. **New Handler**: `handleUpdateSessionStartTime` in `src/App.tsx`
+3. **New Props**: `onUpdateSessionStartTime` in `StudyPlanView`
+4. **New State**: Modal state management in `StudyPlanView`
+5. **New UI**: Edit button and modal in session components
+
+### 📝 Warning Message
+The modal includes a clear warning that changes will be reset if:
+- Settings are modified
+- New tasks are added
+- Study plan is regenerated
+- Other scheduling changes are made
+
+### 🎯 Usage
+1. Click "Edit Time" button on any session
+2. Enter new start time in HH:MM format
+3. Click "Update Time" to apply changes
+4. Session end time is automatically calculated based on duration
+
+The feature is now ready for use and has been tested for compilation and TypeScript compliance.


### PR DESCRIPTION
Add an 'Edit Time' button to study sessions in the study plan view, allowing users to manually adjust session start times while preserving duration.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dc05331-2644-4381-aae1-20861fe6258d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4dc05331-2644-4381-aae1-20861fe6258d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>